### PR TITLE
Remoção da validação do CPNJ ao salvar as configurações em "Melhor Envio > Configurações Gerais"

### DIFF
--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Helper/Data.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Helper/Data.php
@@ -156,12 +156,6 @@ class NovaPC_Melhorenvio_Helper_Data extends Mage_Core_Helper_Abstract
 		return $this->webServiceRequest($url);
 	}
 
-	public function getUserDataFromMelhorEnvio()
-	{
-		$url = $this->_url_init."api/v2/me";
-		return $this->webServiceRequest($url);
-	}
-
 	public function calcularFrete($servicos, $assegurar_valor, $toCep = null, $fromCep = null, $quote = null){
 		foreach ($quote->getAllItems() as $key => $item) {
             $produto = Mage::getModel('catalog/product')->load($item->getProduct()->getId());

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Model/Observer.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Model/Observer.php
@@ -9,32 +9,6 @@ class NovaPC_Melhorenvio_Model_Observer
 			$etiquetaExists = Mage::helper('melhorenvio')->isEtiquetaValidFromOrder($order->getId());
 		}
 	}
-
-	public function validateDataSavedInSystemXml(Varien_Event_Observer $event)
-	{
-		$section = Mage::app()->getRequest()->getParams();
-		if($section['section'] === 'melhorenvio') {
-			$empresaSystem = $section['groups']['empresa']['fields'];
-
-			$dataMelhorEnvio = Mage::helper('melhorenvio')->getUserDataFromMelhorEnvio();
-
-			$cpfMagento = $empresaSystem['cpf']['value'];
-			$cpfMelhorEnvio = $dataMelhorEnvio->document;
-			$cnpjMagento = $empresaSystem['cnpj']['value'];
-			$cnpjMelhorEnvio = $dataMelhorEnvio->company_document;
-
-			$session = Mage::getSingleton('adminhtml/session');
-			
-			if($this->cleanCpfCnpj($cnpjMagento) != $cnpjMelhorEnvio) {
-				$session->addWarning('O CNPJ está diferente do cadastrado na Melhor Envio.');
-			}
-		}
-	}
-
-	protected function cleanCpfCnpj($cpfcnpj)
-	{
-		return preg_replace('/[.\-,\/]/', '', $cpfcnpj);
-	}
 }
 
 ?>

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/etc/config.xml
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/etc/config.xml
@@ -73,14 +73,6 @@
           </melhorenvio>
         </observers>
       </sales_order_save_after>
-      <controller_action_postdispatch_adminhtml_system_config_save>
-        <observers>
-          <controller_action_postdispatch_adminhtml_system_config_save_handle>
-            <class>melhorenvio/observer</class>
-            <method>validateDataSavedInSystemXml</method>
-          </controller_action_postdispatch_adminhtml_system_config_save_handle>
-        </observers>
-      </controller_action_postdispatch_adminhtml_system_config_save>
     </events>
   </global> 
   <admin>


### PR DESCRIPTION
**Tipo das alterações:** PATCH.

Este Pull Request remove a validação do CNPJ que compara se o CNPJ informado em "Melhor Envio > Configurações Gerais > Configurações da Empresa" é igual ao cadastrado na Melhor Envio ao salvar as configurações em "Melhor Envio > Configurações Gerais".