### PR TITLE
Fixed expected return in notifications block.

### DIFF
--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Notifications.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Notifications.php
@@ -44,6 +44,6 @@ class NovaPC_Melhorenvio_Block_Adminhtml_Notifications extends Mage_Adminhtml_Bl
                 Mage::getSingleton('core/session')->{$ms['type']}($ms['message']);
             }
         }
-        return $this;
+        return parent::_toHtml();
     }
 }


### PR DESCRIPTION
Olá, estou enviando a seguinte pull request para corrigir o erro após fazer login no admin no Openmage v20.0.13, com PHP 7.3:
"Recoverable Error: Object of class NovaPC_Melhorenvio_Block_Adminhtml_Notifications could not be converted to string"