### PR TITLE
Correção: Ajuste na Função _toHtml para Retornar uma String no Painel Administrativo

### DIFF
--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Notifications.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Notifications.php
@@ -44,6 +44,6 @@ class NovaPC_Melhorenvio_Block_Adminhtml_Notifications extends Mage_Adminhtml_Bl
                 Mage::getSingleton('core/session')->{$ms['type']}($ms['message']);
             }
         }
-        return $this;
+        return parent::_toHtml();
     }
 }

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Orders/Grid.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Block/Adminhtml/Orders/Grid.php
@@ -22,7 +22,12 @@ class NovaPC_Melhorenvio_Block_Adminhtml_Orders_Grid extends Mage_Adminhtml_Bloc
     
     protected function _prepareCollection() 
     {
-        Mage::helper('melhorenvio')->syncOrders();
+        /**
+         * @author Mageshop <vitor@tryideas.com.br>
+         * Essa função será executada por cron
+         * Melhorando o desepenho da loja, deixando uma tarefa pesada sendo processada em segundo plano.
+         */
+        // Mage::helper('melhorenvio')->syncOrders();
         $collection = Mage::getModel('melhorenvio/orders')->getCollection()->getCustomOrders();
         $this->setCollection($collection);
         $this->getColumn('massaction')->setUseIndex(true);         

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Helper/Data.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Helper/Data.php
@@ -364,19 +364,17 @@ class NovaPC_Melhorenvio_Helper_Data extends Mage_Core_Helper_Abstract
 		if($order == null){
 			// Filtrar registros onde 'url_etiqueta' é NULL e com status "Erro"
 			$collection->addFieldToFilter('url_etiqueta', array('null' => true))
-					   ->addFieldToFilter('status', "Erro")
-					   ->setCurPage($currentPage)
-					   ->setPageSize($pageSize);
+					   ->addFieldToFilter('status', "Erro");
 
-			if($currentPage !== null){
-                // Aplicar essas informações à coleção
-                $collection->setCurPage($currentPage);
-            }
-            if($pageSize !== null){
-                // Aplicar essas informações à coleção
-                $collection->setPageSize($pageSize);
-            }
-        
+			$totalRecords = $collection->getSize();
+			$totalPages = ceil($totalRecords / $pageSize);
+			
+			if ($currentPage > $totalPages) {
+				return false;
+			} else {
+				$collection->setCurPage($currentPage)->setPageSize($pageSize);
+			}
+
 		}else{
 			$collection->addFieldToFilter("increment_id", $order->getData('increment_id'))
  			->addFieldToFilter("status", "Erro")->getFirstItem();
@@ -403,8 +401,6 @@ class NovaPC_Melhorenvio_Helper_Data extends Mage_Core_Helper_Abstract
 			if($collection->count() == 1){
 				return $order->getData("status");
 			}
-
-			unset($order);
 		}
 		
 		// retorno exclusivo para NovaPC_Melhorenvio_Model_Cron

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Model/Cron.php
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/Model/Cron.php
@@ -1,0 +1,25 @@
+<?php
+
+// limite de execucao
+set_time_limit(3600);
+
+/**
+ * @author Mageshop <vitor@tryideas.com.br>
+ * Classe responsável pro sicronizar os pedidos com erros
+ * Summary of NovaPC_Melhorenvio_Model_Cron
+ */
+class NovaPC_Melhorenvio_Model_Cron
+{
+
+    public function jobs()
+    {
+        $pageSize = 50; // Processar 50 pedidos por vez
+        $currentPage = 1;
+
+        do {
+            $result = Mage::helper('melhorenvio')->syncOrders(null, $currentPage, $pageSize);
+            $currentPage++;
+        } while ($result);
+
+    }
+}

--- a/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/etc/config.xml
+++ b/NovaPC_Melhorenvio/app/code/community/NovaPC/Melhorenvio/etc/config.xml
@@ -138,4 +138,18 @@
       </melhorenvio>
     </carriers>
   </default>
+
+  <crontab>
+    <jobs>
+      <melhorenvio_mageshop_jobs>
+        <schedule>
+          <cron_expr>0 */4 * * *</cron_expr>
+        </schedule>
+        <run>
+          <model>melhorenvio/cron::jobs</model>
+        </run>
+      </melhorenvio_mageshop_jobs>
+    </jobs>
+  </crontab>
+  
 </config> 


### PR DESCRIPTION
Problema:
O método _toHtml retornava $this, enquanto o Magento espera uma string, causando erro de conversão.

Correção:
O retorno foi alterado para parent::_toHtml(), garantindo que o método retorne uma string válida.

Fatal error: 
: Uncaught Error: Object of class NovaPC_Melhorenvio_Block_Adminhtml_Notifications could not be converted to string in /home/dev/public_html/app/code/core/Mage/Core/Block/Text.php:71 Stack trace: #0 /home/dev/public_html/app/code/core/Mage/Core/Block/Text/List.php(45): Mage_Core_Block_Text->addText() #1